### PR TITLE
Workaround for authentication and error handling 

### DIFF
--- a/spotifAI/deployment/publish_playlist.py
+++ b/spotifAI/deployment/publish_playlist.py
@@ -45,7 +45,7 @@ class GoogleCacheHandler(CacheHandler):
 
     def save_token_to_cache(self, token_info: dict) -> None:
         pass
-        # to implement (?): update dot-cache version with client.update_secret())
+        # to implement: update dot-cache with refreshed token
 
 
 class SpotifyPlaylistManager:

--- a/spotifAI/deployment/publish_playlist.py
+++ b/spotifAI/deployment/publish_playlist.py
@@ -33,19 +33,18 @@ class GoogleCacheHandler(CacheHandler):
     This implementation loads and saves the cached access tokens to GCP.
     """
 
-    def __init__(self) -> None:
-        self.token_info = json.loads(
+    def get_cached_token(self) -> dict:
+        """Get and return a token_info dictionary object."""
+        return json.loads(
             access_secret_version(
                 "projects/420207002838/secrets/DOT-CACHE/versions/latest"
             )
         )
 
-    def get_cached_token(self) -> dict:
-        return self.token_info
-
     def save_token_to_cache(self, token_info: dict) -> None:
-        pass
+        """Save a token_info dictionary object to the cache and return None."""
         # to implement: update dot-cache with refreshed token
+        return None
 
 
 class SpotifyPlaylistManager:

--- a/spotifAI/deployment/publish_playlist.py
+++ b/spotifAI/deployment/publish_playlist.py
@@ -5,13 +5,47 @@ according to the model's predicted ranking is published via the
 spotify API.
 """
 
+import json
 import logging
 
 import spotipy
 import waitress  # type: ignore
 from flask import Flask, request
 from google.cloud import secretmanager
-from spotipy.oauth2 import SpotifyOAuth
+from spotipy.oauth2 import CacheHandler, SpotifyOAuth
+
+
+def access_secret_version(secret_version_id: str) -> str:
+    """Return the value of a secret's version."""
+    # Create the Secret Manager client.
+    client = secretmanager.SecretManagerServiceClient()
+
+    # Access the secret version.
+    response = client.access_secret_version(name=secret_version_id)
+
+    # Return the decoded payload.
+    return response.payload.data.decode("UTF-8")
+
+
+class GoogleCacheHandler(CacheHandler):
+    """Class with custom implementation of Spotipy's CacheHandler.
+
+    This implementation loads and saves the cached access tokens to GCP.
+    """
+
+    def __init__(self) -> None:
+        self.token_info = json.loads(
+            access_secret_version(
+                "projects/420207002838/secrets/DOT-CACHE/versions/latest"
+            )
+        )
+
+    def get_cached_token(self) -> dict:
+        return self.token_info
+
+    def save_token_to_cache(self, token_info: dict) -> None:
+        pass
+        # to implement (?): update dot-cache version with client.update_secret())
 
 
 class SpotifyPlaylistManager:
@@ -21,16 +55,18 @@ class SpotifyPlaylistManager:
         # authenticate to manage playlist
         scope = "playlist-modify-private"
 
-        cid = self.access_secret_version(
+        cid = access_secret_version(
             "projects/420207002838/secrets/SPOTIFY_CLIENT_ID/versions/latest"
         )
 
-        secret = self.access_secret_version(
+        secret = access_secret_version(
             "projects/420207002838/secrets/SPOTIFY_CLIENT_SECRET/versions/latest"
         )
-        red_uri = self.access_secret_version(
+        red_uri = access_secret_version(
             "projects/420207002838/secrets/SPOTIFY_REDIRECT_URI/versions/latest"
         )
+
+        handler = GoogleCacheHandler()
 
         self.sp = spotipy.Spotify(
             auth_manager=SpotifyOAuth(
@@ -38,21 +74,9 @@ class SpotifyPlaylistManager:
                 client_secret=secret,
                 redirect_uri=red_uri,
                 scope=scope,
-                open_browser=False,
+                cache_handler=handler,
             )
         )
-
-    @staticmethod
-    def access_secret_version(secret_version_id: str) -> str:
-        """Return the value of a secret's version."""
-        # Create the Secret Manager client.
-        client = secretmanager.SecretManagerServiceClient()
-
-        # Access the secret version.
-        response = client.access_secret_version(name=secret_version_id)
-
-        # Return the decoded payload.
-        return response.payload.data.decode("UTF-8")
 
     def publish_playlist(self) -> str:
         """Publish the playlist to a personal Spotify account.

--- a/spotifAI/deployment/publish_playlist.py
+++ b/spotifAI/deployment/publish_playlist.py
@@ -22,19 +22,23 @@ class SpotifyPlaylistManager:
         scope = "playlist-modify-private"
 
         cid = self.access_secret_version(
-            "projects/420207002838/secrets/SPOTIFY_CLIENT_ID/versions/1"
+            "projects/420207002838/secrets/SPOTIFY_CLIENT_ID/versions/latest"
         )
 
         secret = self.access_secret_version(
-            "projects/420207002838/secrets/SPOTIFY_CLIENT_SECRET/versions/1"
+            "projects/420207002838/secrets/SPOTIFY_CLIENT_SECRET/versions/latest"
         )
         red_uri = self.access_secret_version(
-            "projects/420207002838/secrets/SPOTIFY_REDIRECT_URI/versions/1"
+            "projects/420207002838/secrets/SPOTIFY_REDIRECT_URI/versions/latest"
         )
 
         self.sp = spotipy.Spotify(
             auth_manager=SpotifyOAuth(
-                client_id=cid, client_secret=secret, redirect_uri=red_uri, scope=scope, open_browser=False,
+                client_id=cid,
+                client_secret=secret,
+                redirect_uri=red_uri,
+                scope=scope,
+                open_browser=False,
             )
         )
 

--- a/spotifAI/main.py
+++ b/spotifAI/main.py
@@ -44,7 +44,7 @@ class SpotifAIapp:
         self.bucket = self.client.get_bucket("spotifai_bucket")
 
     def run_app(self) -> str:
-        """Function to run the app that determines the content of the playlist to publish.
+        """Function to run the steps required to refresh the future hits playlist.
 
         Returns:
             object: a text with the result of the request to publish the playlist
@@ -59,6 +59,7 @@ class SpotifAIapp:
         s.mount("https://", HTTPAdapter(max_retries=retries))
 
         r = s.post(self.get_new_music_friday_url, headers=self.headers)
+        r.raise_for_status()
 
         df = pd.DataFrame(json.loads(r.text))
 
@@ -86,6 +87,8 @@ class SpotifAIapp:
             data=json.dumps(request_body),
             headers=self.headers,
         )
+        r.raise_for_status()
+
         return r.text
 
 


### PR DESCRIPTION
### Type of change

- [x] Bug fix 
- [ ] Refactoring
- [ ] New feature 

---


### Description
What: 
- A custom cache handler class is implemented to circumvent the user interaction
- Raising for status in the main script to get errors

How:
- By obtaining the latest tokens from DOT-CACHE from the secret manager. Spotipy uses the refreshtoken from the cache to get a new token, which we could use to update the secret with later so that we never have to upload a cachefile manually anymore, but let's test whether this works first. 

Why:
- To hopefully finally fix the bug (and if it persists, to actually throw an error in the cloud scheduler)

---

### Code Checklist
- [x] tested locally
- [x] well-documented (docstrings, type hinting etc.)